### PR TITLE
[UNB-27] Set up Upstash Redis for rate limit counters

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -8,3 +8,7 @@ ANTHROPIC_API_KEY=
 
 # ElevenLabs (Music Generation)
 ELEVENLABS_API_KEY=
+
+# Upstash Redis (rate limiting)
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.2",
+        "@upstash/ratelimit": "^2.0.8",
+        "@upstash/redis": "^1.38.0",
         "clsx": "^2.1.1",
         "midi-writer-js": "^3.2.1",
         "next": "16.2.0",
@@ -3104,6 +3106,39 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.8.tgz",
+      "integrity": "sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+      "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -9656,6 +9691,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.25.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.2",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "clsx": "^2.1.1",
     "midi-writer-js": "^3.2.1",
     "next": "16.2.0",

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,29 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+// Returns undefined when env vars are missing (local dev without Redis configured).
+function createRateLimiter(
+  requests: number,
+  window: `${number} s` | `${number} m` | `${number} h` | `${number} d`
+): Ratelimit | undefined {
+  if (
+    !process.env.UPSTASH_REDIS_REST_URL ||
+    !process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    return undefined;
+  }
+  return new Ratelimit({
+    redis: Redis.fromEnv(),
+    limiter: Ratelimit.slidingWindow(requests, window),
+    analytics: true,
+  });
+}
+
+// Chat endpoint: 20 requests per minute per user
+export const chatRateLimit = createRateLimiter(20, "1 m");
+
+// Arrangement generation: 10 per hour per user
+export const arrangementRateLimit = createRateLimiter(10, "1 h");
+
+// Audio generation: 5 per hour per user
+export const audioRateLimit = createRateLimiter(5, "1 h");


### PR DESCRIPTION
## Summary
- Installs `@upstash/ratelimit` and `@upstash/redis`
- Creates `src/lib/rate-limit.ts` with pre-configured `chatRateLimit`, `arrangementRateLimit`, and `audioRateLimit` sliding-window limiters
- Returns `undefined` when env vars are absent (safe for local dev without Redis)
- Adds `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` to `.env.local.example`

## To activate
Provision an Upstash Redis instance and add the env vars to Vercel.

## Test plan
- [ ] Provision Upstash Redis and add credentials to `.env.local`
- [ ] Import `chatRateLimit` in `/api/chat/route.ts` and verify it gates requests
- [ ] Confirm `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)