### PR TITLE
[UNB-49] MIDI capture engine — onNote callback + midiEventsToNotes

### DIFF
--- a/src/lib/hooks/use-midi-controller.ts
+++ b/src/lib/hooks/use-midi-controller.ts
@@ -31,6 +31,11 @@ export interface UseMidiControllerReturn {
   error: string | null;
 }
 
+export interface UseMidiControllerOptions {
+  /** Fired synchronously for every note-on/note-off, in addition to lastNote. */
+  onNote?: (event: MidiNoteEvent) => void;
+}
+
 function midiNumberToPitch(midiNumber: number): Pitch {
   const noteIndex = midiNumber % 12;
   const octave = Math.floor(midiNumber / 12) - 1;
@@ -49,7 +54,9 @@ function checkMidiSupport(): boolean {
 /**
  * React hook for WebMIDI input.
  */
-export function useMidiController(): UseMidiControllerReturn {
+export function useMidiController(
+  options?: UseMidiControllerOptions,
+): UseMidiControllerReturn {
   const supported = checkMidiSupport();
 
   const [isConnected, setIsConnected] = useState(false);
@@ -59,6 +66,8 @@ export function useMidiController(): UseMidiControllerReturn {
   const [error, setError] = useState<string | null>(null);
 
   const midiAccessRef = useRef<MIDIAccess | null>(null);
+  const onNoteRef = useRef<UseMidiControllerOptions["onNote"]>(options?.onNote);
+  onNoteRef.current = options?.onNote;
 
   const refreshInputs = useCallback(() => {
     const access = midiAccessRef.current;
@@ -132,13 +141,16 @@ export function useMidiController(): UseMidiControllerReturn {
       if (status === 0x90 || status === 0x80) {
         const isNoteOn = status === 0x90 && velocity > 0;
 
-        setLastNote({
+        const noteEvent: MidiNoteEvent = {
           pitch: midiNumberToPitch(noteNumber),
           velocity: isNoteOn ? velocity : 0,
           channel,
           timestamp: event.timeStamp,
           type: isNoteOn ? "noteon" : "noteoff",
-        });
+        };
+
+        setLastNote(noteEvent);
+        onNoteRef.current?.(noteEvent);
       }
     }
 

--- a/src/lib/midi/recorder.test.ts
+++ b/src/lib/midi/recorder.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for midiEventsToNotes — pure MIDI event → Note conversion.
+ *
+ * UNB-49: verify note pairing, chord handling, overlapping notes,
+ * unmatched note-on closure, quantization, and empty input.
+ */
+
+import { describe, it, expect } from "vitest";
+import { midiEventsToNotes } from "./recorder";
+import type { RecordedMidiEvent } from "./recorder";
+import { PPQ } from "@/lib/music/types";
+
+const TRACK_ID = "track-1";
+const BPM = 120;
+
+function ticksFor(ms: number, bpm = BPM): number {
+  return (bpm / 60 / 1000) * PPQ * ms;
+}
+
+describe("midiEventsToNotes", () => {
+  it("returns [] for empty input", () => {
+    expect(midiEventsToNotes([], { trackId: TRACK_ID, bpm: BPM })).toEqual([]);
+  });
+
+  it("converts a single note-on/note-off pair at a known bpm", () => {
+    const events: RecordedMidiEvent[] = [
+      { pitch: "C4", velocity: 100, type: "noteon", timeMs: 0 },
+      { pitch: "C4", velocity: 0, type: "noteoff", timeMs: 500 },
+    ];
+
+    const notes = midiEventsToNotes(events, { trackId: TRACK_ID, bpm: BPM });
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].startTick).toBe(0);
+    expect(notes[0].durationTicks).toBe(Math.round(ticksFor(500)));
+    expect(notes[0].pitch).toBe("C4");
+    expect(notes[0].trackId).toBe(TRACK_ID);
+    expect(notes[0].velocity).toBe(100);
+  });
+
+  it("handles a chord: three simultaneous note-ons/offs, none dropped", () => {
+    const events: RecordedMidiEvent[] = [
+      { pitch: "C4", velocity: 90, type: "noteon", timeMs: 1000 },
+      { pitch: "E4", velocity: 90, type: "noteon", timeMs: 1000 },
+      { pitch: "G4", velocity: 90, type: "noteon", timeMs: 1000 },
+      { pitch: "C4", velocity: 0, type: "noteoff", timeMs: 1400 },
+      { pitch: "E4", velocity: 0, type: "noteoff", timeMs: 1400 },
+      { pitch: "G4", velocity: 0, type: "noteoff", timeMs: 1400 },
+    ];
+
+    const notes = midiEventsToNotes(events, { trackId: TRACK_ID, bpm: BPM });
+
+    expect(notes).toHaveLength(3);
+    const pitches = notes.map((n) => n.pitch).sort();
+    expect(pitches).toEqual(["C4", "E4", "G4"]);
+    const startTicks = new Set(notes.map((n) => n.startTick));
+    expect(startTicks.size).toBe(1);
+  });
+
+  it("handles overlapping notes: A on, B on, A off, B off", () => {
+    const events: RecordedMidiEvent[] = [
+      { pitch: "C4", velocity: 100, type: "noteon", timeMs: 0 },
+      { pitch: "D4", velocity: 100, type: "noteon", timeMs: 200 },
+      { pitch: "C4", velocity: 0, type: "noteoff", timeMs: 600 },
+      { pitch: "D4", velocity: 0, type: "noteoff", timeMs: 900 },
+    ];
+
+    const notes = midiEventsToNotes(events, { trackId: TRACK_ID, bpm: BPM });
+
+    expect(notes).toHaveLength(2);
+    const noteC = notes.find((n) => n.pitch === "C4")!;
+    const noteD = notes.find((n) => n.pitch === "D4")!;
+
+    expect(noteC.startTick).toBe(0);
+    expect(noteC.durationTicks).toBe(Math.round(ticksFor(600)));
+
+    expect(noteD.startTick).toBe(Math.round(ticksFor(200)));
+    expect(noteD.durationTicks).toBe(Math.round(ticksFor(700)));
+  });
+
+  it("closes an unmatched note-on at endMs", () => {
+    const events: RecordedMidiEvent[] = [
+      { pitch: "C4", velocity: 100, type: "noteon", timeMs: 0 },
+    ];
+
+    const notes = midiEventsToNotes(events, {
+      trackId: TRACK_ID,
+      bpm: BPM,
+      endMs: 800,
+    });
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0].startTick).toBe(0);
+    expect(notes[0].durationTicks).toBe(Math.round(ticksFor(800)));
+  });
+
+  it("snaps an off-grid startTick to the nearest quantizeTicks", () => {
+    const quantizeTicks = PPQ / 4; // 120 ticks
+
+    // Dummy earlier note pins baseMs at 0 so the C4 note below lands
+    // off-grid: ticksPerMs = 0.96, onMs=100 -> raw startTick = round(96) = 96,
+    // which is NOT a multiple of 120 and should snap to the nearest one (120).
+    const events: RecordedMidiEvent[] = [
+      { pitch: "E4", velocity: 100, type: "noteon", timeMs: 0 },
+      { pitch: "E4", velocity: 0, type: "noteoff", timeMs: 50 },
+      { pitch: "C4", velocity: 100, type: "noteon", timeMs: 100 },
+      { pitch: "C4", velocity: 0, type: "noteoff", timeMs: 400 },
+    ];
+
+    const notes = midiEventsToNotes(events, {
+      trackId: TRACK_ID,
+      bpm: BPM,
+      quantizeTicks,
+    });
+
+    const noteC = notes.find((n) => n.pitch === "C4")!;
+    expect(noteC.startTick % quantizeTicks).toBe(0);
+    expect(noteC.startTick).toBe(120);
+  });
+});

--- a/src/lib/midi/recorder.ts
+++ b/src/lib/midi/recorder.ts
@@ -1,0 +1,101 @@
+/**
+ * Pure conversion of raw MIDI note-on/note-off events (as captured live from
+ * a WebMIDI input) into sequencer Notes. No React/Tone/DOM dependency —
+ * mirrors the ms-to-tick conversion in `hum-to-midi.ts#segmentsToNotes`.
+ */
+
+import type { Note, Pitch } from "@/lib/music/types";
+import { PPQ } from "@/lib/music/types";
+
+export interface RecordedMidiEvent {
+  pitch: Pitch;
+  velocity: number; // 0-127 (0 for note-off)
+  type: "noteon" | "noteoff";
+  timeMs: number; // monotonic, e.g. from event.timeStamp
+}
+
+export interface MidiToNotesOptions {
+  trackId: string;
+  bpm: number;
+  /** Optional grid snap in ticks, e.g. PPQ/4 */
+  quantizeTicks?: number;
+  /** Time of record end, used to close still-held notes */
+  endMs?: number;
+}
+
+interface OpenNoteOn {
+  velocity: number;
+  timeMs: number;
+}
+
+/** Snap a tick value to the nearest multiple of `grid`. */
+function quantize(tick: number, grid: number): number {
+  return Math.round(tick / grid) * grid;
+}
+
+/**
+ * Convert recorded MIDI note-on/note-off events into Note objects targeting
+ * a specific track. Note IDs are NOT assigned — the caller must add them.
+ */
+export function midiEventsToNotes(
+  events: RecordedMidiEvent[],
+  opts: MidiToNotesOptions,
+): Omit<Note, "id">[] {
+  if (events.length === 0) return [];
+
+  const sorted = events
+    .map((event, index) => ({ event, index }))
+    .sort((a, b) => a.event.timeMs - b.event.timeMs || a.index - b.index)
+    .map(({ event }) => event);
+
+  const baseMs = Math.min(...sorted.map((e) => e.timeMs));
+  const maxMs = Math.max(...sorted.map((e) => e.timeMs));
+  const closeMs = opts.endMs ?? maxMs;
+
+  const ticksPerMs = (opts.bpm / 60 / 1000) * PPQ;
+  const quantizeTicks = opts.quantizeTicks;
+
+  const openByPitch = new Map<Pitch, OpenNoteOn[]>();
+  const notes: Omit<Note, "id">[] = [];
+
+  function buildNote(pitch: Pitch, onMs: number, offMs: number, velocity: number): Omit<Note, "id"> {
+    let startTick = Math.round((onMs - baseMs) * ticksPerMs);
+    let durationTicks = Math.max(1, Math.round((offMs - onMs) * ticksPerMs));
+
+    if (quantizeTicks && quantizeTicks > 0) {
+      startTick = quantize(startTick, quantizeTicks);
+      durationTicks = Math.max(1, Math.max(quantizeTicks, durationTicks));
+    }
+
+    return {
+      trackId: opts.trackId,
+      pitch,
+      startTick,
+      durationTicks,
+      velocity: Math.max(1, Math.min(127, Math.round(velocity))),
+    };
+  }
+
+  for (const event of sorted) {
+    if (event.type === "noteon") {
+      const open = openByPitch.get(event.pitch) ?? [];
+      open.push({ velocity: event.velocity, timeMs: event.timeMs });
+      openByPitch.set(event.pitch, open);
+    } else {
+      const open = openByPitch.get(event.pitch);
+      const pending = open?.shift();
+      if (pending) {
+        notes.push(buildNote(event.pitch, pending.timeMs, event.timeMs, pending.velocity));
+      }
+    }
+  }
+
+  // Close any note-ons that never received a matching note-off.
+  for (const [pitch, open] of openByPitch) {
+    for (const pending of open) {
+      notes.push(buildNote(pitch, pending.timeMs, closeMs, pending.velocity));
+    }
+  }
+
+  return notes;
+}


### PR DESCRIPTION
# Story 1: MIDI capture engine (event callback + pure notes conversion)

## Context
Project: unbottle (/Users/xsab020/projects/personal/unbottle)
Foundation slice — no UI. Story 2 depends on this.

Relevant files:
- `src/lib/hooks/use-midi-controller.ts` — Web MIDI hook. Currently exposes only
  `lastNote` (single React state slot). Its `onmidimessage` handler (lines
  ~121-148) parses status 0x90/0x80 into a `MidiNoteEvent { pitch, velocity,
  channel, timestamp, type }`.
- `src/lib/audio/hum-to-midi.ts` — `segmentsToNotes(segments, trackId, bpm)`
  shows the exact ms→tick conversion to mirror:
  `const ticksPerMs = (bpm / 60 / 1000) * PPQ;`
- `src/lib/music/types.ts` — `Note { id, trackId, pitch, startTick,
  durationTicks, velocity }`, `PPQ = 480`, `Pitch` is a string like `"C4"`.

Stack notes:
- Next.js 16 / React 19 / TypeScript strict. Read AGENTS.md + CLAUDE.md FIRST —
  this is a modified Next.js; consult `node_modules/next/dist/docs/` before
  writing framework code. (This story is pure TS + a hook, minimal framework
  surface.)
- Tests use vitest (`npm test`). Mirror the style of
  `src/lib/audio/hum-to-midi.ts` tests / `src/lib/midi/midi-learn.test.ts`.

## What to build

1. **Add an `onNote` callback to `useMidiController`.**
   - Change the hook to accept an optional options arg:
     `useMidiController(options?: { onNote?: (e: MidiNoteEvent) => void }): UseMidiControllerReturn`.
   - Keep it backward compatible: called with no args must behave exactly as
     today (`lastNote` still updates). The hook's only existing consumer is its
     test, so back-compat is about not breaking that.
   - In the `onmidimessage` handler, after building the `MidiNoteEvent`, call the
     `onNote` callback **synchronously** (via a ref to the latest callback so the
     effect doesn't re-subscribe on every render) in addition to `setLastNote`.
     This is what lets Story 2 capture chords without React state coalescing.

2. **New pure module `src/lib/midi/recorder.ts`** exporting:
   ```ts
   export interface RecordedMidiEvent {
     pitch: Pitch;
     velocity: number;      // 0-127 (0 for note-off)
     type: "noteon" | "noteoff";
     timeMs: number;        // monotonic, e.g. from event.timeStamp
   }
   export interface MidiToNotesOptions {
     trackId: string;
     bpm: number;
     /** Optional grid quantize in ticks (e.g. PPQ/4 = 16th). Omit = no quantize. */
     quantizeTicks?: number;
     /** Time of record end in ms, used to close still-held notes. */
     endMs?: number;
   }
   export function midiEventsToNotes(
     events: RecordedMidiEvent[],
     opts: MidiToNotesOptions,
   ): Omit<Note, "id">[];
   ```
   Behaviour:
   - Sort events by `timeMs` (stable).
   - Pair each `noteon` with the next `noteoff` of the SAME pitch. Support
     overlapping/simultaneous notes of different pitches (a chord = several
     note-ons at ~same `timeMs`, each paired independently). If multiple
     note-ons for the same pitch are stacked before a note-off, pair FIFO.
   - `startMs` = first recorded event's `timeMs` is the zero reference, so the
     earliest note starts at tick 0. i.e. offset all times by the minimum
     `timeMs` among events.
   - Convert with `ticksPerMs = (bpm / 60 / 1000) * PPQ`:
     `startTick = round((onMs - baseMs) * ticksPerMs)`,
     `durationTicks = max(1, round((offMs - onMs) * ticksPerMs))`.
   - A note-on with no matching note-off is closed at `opts.endMs` (or the last
     event time if `endMs` omitted); still `max(1, ...)` duration.
   - If `quantizeTicks` is set, snap `startTick` to the nearest multiple and keep
     `durationTicks` a minimum of one grid step.
   - Carry `velocity` from the note-on (clamp 1-127). `trackId` from opts.
   - Return `Omit<Note,"id">[]` (no ids — caller assigns), exactly like
     `segmentsToNotes`.

3. **Tests `src/lib/midi/recorder.test.ts`** covering:
   - Single note → one Note with correct startTick/durationTicks for a known bpm.
   - Chord: three note-ons at the same `timeMs`, three matching note-offs →
     three notes with the same `startTick`, none dropped.
   - Overlapping notes (A on, B on, A off, B off) → two correctly-sized notes.
   - Unmatched note-on (no note-off) → closed at `endMs`.
   - Quantize: an off-grid `startTick` snaps to the nearest `quantizeTicks`.
   - Empty input → `[]`.

## Acceptance criteria
- [ ] `useMidiController({ onNote })` fires `onNote` for every note-on/off,
      synchronously in the message handler; no-arg usage unchanged; hook does not
      re-subscribe to the device on every render (callback held in a ref).
- [ ] `midiEventsToNotes` implemented per the behaviour above, pure (no React, no
      Tone, no DOM), returning `Omit<Note,"id">[]`.
- [ ] Tests cover single note, chord, overlap, unmatched note-on, quantize, empty
      — all passing.

## Definition of done
- [ ] TypeScript compiles (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] PR opened with Tack story ID in title

---
Part of epic UNB-35. Preflight: lint 0 errors, tsc clean, 866 tests pass (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)