### PR TITLE
[UNB-50] MIDI keyboard recording panel + session wiring

### DIFF
--- a/src/app/(app)/session/[id]/page.tsx
+++ b/src/app/(app)/session/[id]/page.tsx
@@ -8,6 +8,7 @@ import { TransportControls } from "@/components/sequencer/transport-controls";
 import { ArrangementPanel } from "@/components/arrangement/arrangement-panel";
 import { ChatPanel } from "@/components/chat/chat-panel";
 import { CapturePanel } from "@/components/capture/capture-panel";
+import { MidiRecordPanel } from "@/components/instruments/midi-record-panel";
 import { SequencerPanel } from "@/components/sequencer/sequencer-panel";
 import { ExportDialog } from "@/components/export/export-dialog";
 import { SheetMusicView } from "@/components/sheet-music/sheet-music-view";
@@ -31,6 +32,7 @@ import { reorderSections } from "@/lib/music/section-reorder";
 import { getSectionTickRange, copyNotesForSection } from "@/lib/audio/playback-utils";
 import { ActionHistory } from "@/lib/session/action-history";
 import type { SessionSnapshot } from "@/lib/session/action-history";
+import { midiEventsToNotes, type RecordedMidiEvent } from "@/lib/midi/recorder";
 import type { ChatAction, ChatContext } from "@/lib/hooks/use-chat";
 import { PPQ } from "@/lib/music/types";
 import type { Bookmark, InstrumentType, Note, Section, SectionType, ChordEvent } from "@/lib/music/types";
@@ -434,6 +436,53 @@ export default function SessionWorkspacePage() {
           variant: "error",
         });
       }
+    },
+    [session, tracks, refreshSession, sequencer, addToast],
+  );
+
+  // ------- MIDI recording: capture raw MIDI events into notes -------
+  const handleMidiCapture = useCallback(
+    async (events: RecordedMidiEvent[]) => {
+      if (!session || events.length === 0) {
+        addToast({ message: "No MIDI notes recorded", variant: "error" });
+        return;
+      }
+
+      // Find an existing "MIDI" track or create one. We don't reuse the
+      // first track because that's usually a piano/bass and stomping notes
+      // onto it would surprise the user.
+      let midiTrack = tracks.find((t) => t.name.toLowerCase().includes("midi"));
+      if (!midiTrack) {
+        const r = await fetch(`/api/session/${session.id}/tracks`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: "MIDI", instrument: "piano" }),
+        });
+        if (r.ok) {
+          const { track } = (await r.json()) as { track: typeof tracks[number] };
+          midiTrack = track;
+          await refreshSession();
+        }
+      }
+
+      if (!midiTrack) {
+        addToast({ message: "Failed to create MIDI track", variant: "error" });
+        return;
+      }
+
+      const endMs = Math.max(...events.map((e) => e.timeMs));
+      const partial = midiEventsToNotes(events, {
+        trackId: midiTrack.id,
+        bpm: session.bpm ?? 120,
+        endMs,
+      });
+      const notes: Note[] = partial.map((n, idx) => ({
+        ...n,
+        id: `midi_${n.startTick}_${idx}`,
+      }));
+      sequencer.addBulkNotes(notes);
+
+      addToast({ message: `Added ${notes.length} notes from MIDI`, variant: "success" });
     },
     [session, tracks, refreshSession, sequencer, addToast],
   );
@@ -1457,13 +1506,20 @@ export default function SessionWorkspacePage() {
         )}
 
         {mobileTab === "capture" && (
-          <CapturePanel
-            collapsed={false}
-            onAddToSession={handleCaptureAddToSession}
-            onTranscribeToMidi={handleTranscribeToMidi}
-            sessionId={session.id}
-            className="flex-1 w-full border-l-0"
-          />
+          <div className="flex flex-1 flex-col overflow-y-auto">
+            <CapturePanel
+              collapsed={false}
+              onAddToSession={handleCaptureAddToSession}
+              onTranscribeToMidi={handleTranscribeToMidi}
+              sessionId={session.id}
+              className="w-full flex-1 border-l-0"
+            />
+            <MidiRecordPanel
+              bpm={session.bpm ?? 120}
+              onCapture={handleMidiCapture}
+              className="m-3 mt-0"
+            />
+          </div>
         )}
       </div>
 
@@ -1634,7 +1690,7 @@ export default function SessionWorkspacePage() {
               className="fixed inset-0 z-30"
               onClick={() => setCaptureOpen(false)}
             />
-            <div className="fixed bottom-24 right-6 z-40 w-80 rounded-2xl border border-neutral-700 bg-[#0a0a0a] shadow-2xl shadow-black/50">
+            <div className="fixed bottom-24 right-6 z-40 max-h-[80vh] w-80 overflow-y-auto rounded-2xl border border-neutral-700 bg-[#0a0a0a] shadow-2xl shadow-black/50">
               <CapturePanel
                 collapsed={false}
                 onAddToSession={handleCaptureAddToSession}
@@ -1642,6 +1698,12 @@ export default function SessionWorkspacePage() {
                 sessionId={session.id}
                 className="border-l-0 rounded-2xl"
               />
+              <div className="border-t border-neutral-800 p-3">
+                <MidiRecordPanel
+                  bpm={session.bpm ?? 120}
+                  onCapture={handleMidiCapture}
+                />
+              </div>
             </div>
           </>
         )}

--- a/src/components/instruments/midi-record-panel.tsx
+++ b/src/components/instruments/midi-record-panel.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useMidiController, type MidiNoteEvent } from "@/lib/hooks/use-midi-controller";
+import type { RecordedMidiEvent } from "@/lib/midi/recorder";
+import { initAudio, createInstrument } from "@/lib/audio/tone-setup";
+import type { Pitch } from "@/lib/music/types";
+import { cn } from "@/lib/utils/cn";
+
+/** Minimal shape of the lazily-created preview instrument (a Tone node). */
+interface PreviewInstrument {
+  triggerAttack?: (pitch: string, time?: number, velocity?: number) => void;
+  triggerRelease?: (pitch: string) => void;
+  releaseAll?: () => void;
+  dispose?: () => void;
+}
+
+export interface MidiRecordPanelProps {
+  bpm: number;
+  onCapture: (events: RecordedMidiEvent[]) => void;
+  className?: string;
+}
+
+export function MidiRecordPanel({ bpm, onCapture, className }: MidiRecordPanelProps) {
+  const [recording, setRecording] = useState(false);
+  const [noteCount, setNoteCount] = useState(0);
+  const [lastPitch, setLastPitch] = useState<Pitch | null>(null);
+
+  const recordingRef = useRef(false);
+  const bufferRef = useRef<RecordedMidiEvent[]>([]);
+  const instRef = useRef<PreviewInstrument | null>(null);
+
+  const handleNote = useCallback((e: MidiNoteEvent) => {
+    const inst = instRef.current;
+    if (inst) {
+      try {
+        if (e.type === "noteon") {
+          inst.triggerAttack?.(e.pitch, undefined, e.velocity / 127);
+        } else {
+          inst.triggerRelease?.(e.pitch);
+        }
+      } catch {
+        // Ignore individual note errors
+      }
+    }
+
+    if (recordingRef.current) {
+      bufferRef.current.push({
+        pitch: e.pitch,
+        velocity: e.velocity,
+        type: e.type,
+        timeMs: e.timestamp,
+      });
+
+      if (e.type === "noteon") {
+        setNoteCount((c) => c + 1);
+        setLastPitch(e.pitch);
+      }
+    }
+  }, []);
+
+  const { isSupported, midiInputs, selectedInput, setSelectedInput, error } =
+    useMidiController({ onNote: handleNote });
+
+  const handleRecordClick = useCallback(async () => {
+    await initAudio();
+    if (!instRef.current) {
+      instRef.current = (await createInstrument("synth")) as PreviewInstrument;
+    }
+    bufferRef.current = [];
+    setNoteCount(0);
+    setLastPitch(null);
+    recordingRef.current = true;
+    setRecording(true);
+  }, []);
+
+  const handleStopClick = useCallback(() => {
+    recordingRef.current = false;
+    setRecording(false);
+    if (bufferRef.current.length > 0) {
+      onCapture([...bufferRef.current]);
+    }
+    bufferRef.current = [];
+  }, [onCapture]);
+
+  // Cleanup preview instrument on unmount
+  useEffect(() => {
+    return () => {
+      recordingRef.current = false;
+      const inst = instRef.current;
+      if (inst) {
+        try {
+          inst.releaseAll?.();
+        } catch {
+          // ignore
+        }
+        try {
+          inst.dispose?.();
+        } catch {
+          // ignore
+        }
+      }
+      instRef.current = null;
+    };
+  }, []);
+
+  if (!isSupported) {
+    return (
+      <div className={cn("rounded-lg border border-neutral-700 p-4", className)}>
+        <h3 className="text-sm font-medium text-neutral-200 mb-1">MIDI Keyboard</h3>
+        <p className="text-xs text-neutral-500">Web MIDI needs Chrome or Edge.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("rounded-lg border border-neutral-700 p-4", className)}>
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-medium text-neutral-200">MIDI Keyboard</h3>
+        <span className="text-xs text-neutral-500">{bpm} BPM</span>
+      </div>
+
+      {midiInputs.length === 0 ? (
+        <p className="mb-3 text-xs text-neutral-500">
+          No MIDI device — connect one and it&apos;ll appear.
+        </p>
+      ) : (
+        <select
+          value={selectedInput ?? ""}
+          onChange={(e) => setSelectedInput(e.target.value || null)}
+          className="mb-3 w-full rounded-md border border-neutral-700 bg-neutral-800 px-2 py-1.5 text-xs text-neutral-200"
+        >
+          {midiInputs.map((input) => (
+            <option key={input.id} value={input.id}>
+              {input.name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <button
+        type="button"
+        onClick={recording ? handleStopClick : handleRecordClick}
+        disabled={midiInputs.length === 0}
+        className={cn(
+          "w-full rounded-lg px-3 py-2 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40",
+          recording
+            ? "animate-pulse bg-red-500/20 text-red-400"
+            : "bg-amber-500 text-[#0a0a0a] hover:bg-amber-400",
+        )}
+      >
+        {recording ? "■ Stop" : "● Record"}
+      </button>
+
+      {recording && (
+        <div className="mt-2 flex items-center gap-2 text-xs text-neutral-400">
+          <span className="h-2 w-2 flex-shrink-0 animate-pulse rounded-full bg-red-500" />
+          <span>{noteCount} notes</span>
+          {lastPitch && <span className="text-neutral-500">· {lastPitch}</span>}
+        </div>
+      )}
+
+      {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
# Story 2: MIDI recording panel + session wiring

## Context
Project: unbottle (/Users/xsab020/projects/personal/unbottle)
Depends on Story 1 (`useMidiController({ onNote })` and
`src/lib/midi/recorder.ts` → `midiEventsToNotes`). Those MUST be merged/present
before this story. This is the integration + UI slice that makes playing a MIDI
keyboard produce visible notes + sheet music.

Relevant files:
- `src/lib/hooks/use-midi-controller.ts` — `useMidiController({ onNote })`:
  `{ isSupported, isConnected, midiInputs: {id,name,manufacturer}[],
  selectedInput, setSelectedInput, lastNote, error }`.
- `src/lib/midi/recorder.ts` — `midiEventsToNotes(events, { trackId, bpm, endMs, quantizeTicks? })`
  and `RecordedMidiEvent { pitch, velocity, type, timeMs }`.
- `src/lib/audio/tone-setup.ts` — `initAudio()` (calls `Tone.start()`, MUST run
  on a user gesture) and `createInstrument(type)` → connected Tone
  PolySynth/Sampler with `triggerAttack(pitch, time, velocity)` /
  `triggerRelease(pitch)`. Use `"synth"` for a light preview instrument.
- `src/app/(app)/session/[id]/page.tsx` — `const sequencer = useSequencer(...)`
  (line ~89). `handleTranscribeToMidi` (lines ~354-403) is the template:
  find-or-create a named track via `POST /api/session/:id/tracks`
  (`body: { name, instrument: "piano" }`, returns `{ track }`), then
  `refreshSession()`, assign ids, `sequencer.addBulkNotes(notes)`. The Capture
  UI mounts as a mobile tab AND a floating desktop popover (FAB) around lines
  1460 and 1617-1648. `session.bpm`, `session.keySignature`, `tracks`,
  `refreshSession`, `addToast` are all in scope there.
- `src/components/instruments/midi-inputs-panel.tsx` — existing device-list panel
  styling to match (dark rounded card, `border-neutral-700`, etc.).

Stack notes:
- Next.js 16 / React 19 / TS strict. Read AGENTS.md + CLAUDE.md FIRST; this is a
  modified Next.js — check `node_modules/next/dist/docs/` before framework code.
- Client component → `"use client"`.
- Notes render in both piano roll and sheet music straight from
  `sequencer.notes`, and MIDI export reads the same — so once notes land via
  `sequencer.addBulkNotes`, NO new render/export code is needed.
- Match the neutral/amber dark theme used across the session UI.

## What to build

1. **`src/components/instruments/midi-record-panel.tsx`** (`MidiRecordPanel`):
   - Props: `{ bpm: number; onCapture: (notes: Omit<Note,"id">[]) => void;
     className?: string }`.
   - Uses `useMidiController({ onNote })`. `onNote`:
     - Always route through a preview: on `noteon` call
       `instrument.triggerAttack(pitch, undefined, velocity/127)`; on `noteoff`
       call `instrument.triggerRelease(pitch)`. Lazily build the preview
       instrument (`createInstrument("synth")`) after `initAudio()`; guard for
       not-yet-loaded.
     - When armed/recording, push a `RecordedMidiEvent { pitch, velocity, type,
       timeMs: e.timestamp }` into a recording buffer (use a ref, not state, so
       fast input isn't lost).
   - UI:
     - If `!isSupported`: show a graceful message ("Web MIDI needs Chrome or
       Edge") and render nothing else.
     - Device `<select>` bound to `selectedInput` / `setSelectedInput`, listing
       `midiInputs`. If `midiInputs` is empty: "No MIDI device — connect one."
     - A Record / Stop toggle button. On Record click: call `initAudio()`, clear
       the buffer, set recording=true. On Stop: recording=false, compute
       `endMs` (last event time or `performance`-free — use the last buffered
       event's `timeMs`), call `midiEventsToNotes(buffer, { trackId: "",
       bpm, endMs })` — BUT trackId is assigned by the caller, so instead pass
       the raw buffer up: simpler contract is to call
       `onCapture(midiEventsToNotes(buffer, { trackId: PLACEHOLDER, bpm, endMs }))`
       and let the page overwrite `trackId`. To avoid a placeholder, prefer:
       expose the conversion in the panel but set `trackId` to a temp value and
       have the page remap it — OR (cleaner) have `onCapture` receive the raw
       `RecordedMidiEvent[]` plus `bpm` and let the page call
       `midiEventsToNotes` with the real track id. **Choose the cleaner option:
       `onCapture(events: RecordedMidiEvent[])`** and do the notes conversion in
       the page where the trackId is known.
     - Live status while recording: a pulsing red dot + note-on count (increment
       a state counter on each `noteon`), and the last played pitch.
   - Clean up: on unmount, `triggerRelease` any held notes / dispose the preview
     instrument if it created its own (don't dispose cached instruments from
     `createInstrument` — it caches samplers; the "synth" path returns a fresh
     PolySynth each call, so keep a single ref and dispose that on unmount).

2. **Wire into `src/app/(app)/session/[id]/page.tsx`:**
   - Add `handleMidiCapture(events: RecordedMidiEvent[])` mirroring
     `handleTranscribeToMidi`:
     - If no events, `addToast({ message: "No notes recorded", variant: "error" })`
       and return.
     - Find a track whose name includes "midi" (case-insensitive); if none,
       `POST /api/session/${session.id}/tracks` with
       `{ name: "MIDI", instrument: "piano" }`, read `{ track }`, `refreshSession()`.
     - `const partial = midiEventsToNotes(events, { trackId: track.id,
       bpm: session.bpm ?? 120, endMs })` — compute `endMs` as the max event
       `timeMs`.
     - Map to `Note[]` with ids (`midi_${index}_${pitchtick}` style — no
       `Date.now()` needed; a stable counter + startTick suffices) and
       `sequencer.addBulkNotes(notes)`.
     - `addToast({ message: `Added ${notes.length} notes from MIDI`, variant: "success" })`.
   - Mount `<MidiRecordPanel bpm={session.bpm ?? 120} onCapture={handleMidiCapture} />`
     in a sensible, discoverable spot — put it inside the same floating Capture
     popover area (a small section under `CapturePanel`) AND in the mobile
     capture tab, so it's reachable on both layouts. Keep it visually consistent
     with the surrounding dark panels.

3. **Graceful degradation:** unsupported browser / no device must not throw and
   must show the messages above.

## Acceptance criteria
- [ ] Selecting a device, clicking Record, playing keys, then Stop adds the
      played notes to a found-or-created "MIDI" track; they appear in the piano
      roll and the sheet music view and are included in MIDI export.
- [ ] Pressed keys are audible during recording (preview instrument via Tone.js,
      `initAudio()` triggered by the Record gesture).
- [ ] A chord (multiple keys at once) records all its notes, none dropped.
- [ ] Unsupported browser or no connected device shows a clear message and does
      not crash.
- [ ] The panel is mounted and reachable in the session UI on desktop and mobile.

## Definition of done
- [ ] TypeScript compiles (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Tests pass (`npm test`)
- [ ] PR opened with Tack story ID in title

---
Part of epic UNB-35. Depends on #266 (UNB-49, merged). Preflight: lint 0 errors, tsc clean, 866 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)