### PR TITLE
[UNB-54] Make AI-generated arrangements produce actual notes

### DIFF
--- a/src/app/(app)/session/[id]/page.tsx
+++ b/src/app/(app)/session/[id]/page.tsx
@@ -35,7 +35,7 @@ import type { SessionSnapshot } from "@/lib/session/action-history";
 import { midiEventsToNotes, type RecordedMidiEvent } from "@/lib/midi/recorder";
 import type { ChatAction, ChatContext } from "@/lib/hooks/use-chat";
 import { PPQ } from "@/lib/music/types";
-import type { Bookmark, InstrumentType, Note, Section, SectionType, ChordEvent } from "@/lib/music/types";
+import type { Bookmark, InstrumentType, Note, Section, SectionType, ChordEvent, Track } from "@/lib/music/types";
 import { useDawMode } from "@/lib/hooks/use-daw-mode";
 import { executeDAWTool } from "@/lib/daw/executor";
 import { ToneBackend } from "@/lib/daw/backends/tone-backend";
@@ -93,6 +93,13 @@ export default function SessionWorkspacePage() {
   // ------- AI Action undo history -------
   const aiHistory = useRef(new ActionHistory());
   const [canUndoAI, setCanUndoAI] = useState(false);
+
+  // Tracks the AI just asked to create, keyed by lowercased name, resolving to
+  // the real persisted Track once the add_track POST completes. Populated
+  // synchronously when the request is *initiated* so a generate_notation call
+  // for the same track (streamed moments later, before `tracks` state has
+  // refreshed) can await the real track instead of falling back to tracks[0].
+  const pendingTracksRef = useRef<Map<string, Promise<Track | null>>>(new Map());
 
   const snapshotSession = useCallback((): SessionSnapshot => ({
     sections: [...sections],
@@ -559,15 +566,17 @@ export default function SessionWorkspacePage() {
               duration: 3000,
             });
 
-            // Auto-place chords in sequencer and auto-play
+            // Auto-place chords in sequencer (fallback so every existing track has
+            // something audible even before/if generate_notation fires) and auto-play
             setTimeout(() => {
               if (tracks.length > 0) {
-                const trackId = tracks[0].id;
-                const chordNotes = chordProgressionToNotes(
-                  newSections as Section[],
-                  trackId,
-                  input.bpm ?? session?.bpm ?? 120,
-                  session?.timeSignature ?? "4/4",
+                const chordNotes = tracks.flatMap((t) =>
+                  chordProgressionToNotes(
+                    newSections as Section[],
+                    t.id,
+                    input.bpm ?? session?.bpm ?? 120,
+                    session?.timeSignature ?? "4/4",
+                  ),
                 );
                 if (chordNotes.length > 0) {
                   sequencer.addBulkNotes(chordNotes);
@@ -606,16 +615,21 @@ export default function SessionWorkspacePage() {
         };
 
         if (session) {
-          fetch(`/api/session/${session.id}/tracks`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              name: input.name,
-              instrument: input.instrument,
-            }),
-          })
-            .then((res) => {
+          const trackKey = input.name.toLowerCase();
+          const trackPromise: Promise<Track | null> = fetch(
+            `/api/session/${session.id}/tracks`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                name: input.name,
+                instrument: input.instrument,
+              }),
+            },
+          )
+            .then(async (res) => {
               if (res.ok) {
+                const data = (await res.json()) as { track: Track };
                 addToast({
                   message: `Track '${input.name}' added`,
                   variant: "success",
@@ -623,19 +637,25 @@ export default function SessionWorkspacePage() {
                 });
                 // Refresh session to pick up the new track in state
                 void refreshSession();
-              } else {
-                addToast({
-                  message: "Failed to add track",
-                  variant: "error",
-                });
+                return data.track;
               }
+              addToast({
+                message: "Failed to add track",
+                variant: "error",
+              });
+              return null;
             })
             .catch(() => {
               addToast({
                 message: "Failed to add track",
                 variant: "error",
               });
+              return null;
             });
+
+          // Store synchronously (before the request settles) so a
+          // generate_notation call for this same track name can find it.
+          pendingTracksRef.current.set(trackKey, trackPromise);
         }
       } else if (action.toolName === "generate_notation") {
         const input = action.toolInput as {
@@ -649,31 +669,46 @@ export default function SessionWorkspacePage() {
           description?: string;
         };
 
-        // Find the target track by name
-        const targetTrack = tracks.find(
-          (t) => t.name.toLowerCase() === input.trackName.toLowerCase(),
-        ) ?? tracks[0];
+        const applyNotation = async () => {
+          // Find the target track by name in current state first...
+          let targetTrack = tracks.find(
+            (t) => t.name.toLowerCase() === input.trackName.toLowerCase(),
+          );
 
-        if (targetTrack && input.notes?.length) {
-          const newNotes: Note[] = input.notes.map((n, idx) => ({
-            id: `ai_note_${Date.now()}_${idx}`,
-            trackId: targetTrack.id,
-            pitch: n.pitch as Note["pitch"],
-            startTick: Math.round((n.startBeat - 1) * PPQ),
-            durationTicks: Math.round(n.durationBeats * PPQ),
-            velocity: n.velocity ?? 80,
-          }));
+          // ...otherwise it may be a track that was just created via add_track
+          // in this same streamed response and hasn't reached `tracks` state yet.
+          if (!targetTrack) {
+            const pending = pendingTracksRef.current.get(input.trackName.toLowerCase());
+            if (pending) {
+              targetTrack = (await pending) ?? undefined;
+            }
+          }
 
-          sequencer.addBulkNotes(newNotes);
-          setSequencerVisible(true);
-          setSheetMusicVisible(true);
+          targetTrack = targetTrack ?? tracks[0];
 
-          addToast({
-            message: `${newNotes.length} notes added${input.description ? `: ${input.description}` : ""}`,
-            variant: "success",
-            duration: 3000,
-          });
-        }
+          if (targetTrack && input.notes?.length) {
+            const newNotes: Note[] = input.notes.map((n, idx) => ({
+              id: `ai_note_${Date.now()}_${idx}`,
+              trackId: targetTrack.id,
+              pitch: n.pitch as Note["pitch"],
+              startTick: Math.round((n.startBeat - 1) * PPQ),
+              durationTicks: Math.round(n.durationBeats * PPQ),
+              velocity: n.velocity ?? 80,
+            }));
+
+            sequencer.addBulkNotes(newNotes);
+            setSequencerVisible(true);
+            setSheetMusicVisible(true);
+
+            addToast({
+              message: `${newNotes.length} notes added${input.description ? `: ${input.description}` : ""}`,
+              variant: "success",
+              duration: 3000,
+            });
+          }
+        };
+
+        void applyNotation();
       } else if (action.toolName === "suggest_lyrics") {
         const input = action.toolInput as {
           sectionName: string;

--- a/src/lib/ai/prompts/producer.test.ts
+++ b/src/lib/ai/prompts/producer.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { buildProducerSystemPrompt } from "./producer";
+
+function baseSession() {
+  return {
+    bpm: 120,
+    keySignature: "C major",
+    timeSignature: "4/4",
+  };
+}
+
+describe("buildProducerSystemPrompt", () => {
+  it("documents generate_notation as a tool the AI can use", () => {
+    const prompt = buildProducerSystemPrompt(baseSession());
+    expect(prompt).toContain("generate_notation");
+  });
+
+  it("instructs the AI that generate_arrangement alone does not produce playable notes", () => {
+    const prompt = buildProducerSystemPrompt(baseSession());
+    expect(prompt.toLowerCase()).toContain("does not put playable notes");
+  });
+
+  it("includes a critical rule requiring generate_notation after building sections/tracks", () => {
+    const prompt = buildProducerSystemPrompt(baseSession());
+    const criticalRulesSection = prompt.slice(prompt.indexOf("CRITICAL RULES"));
+    expect(criticalRulesSection).toContain("generate_notation");
+  });
+});

--- a/src/lib/ai/prompts/producer.ts
+++ b/src/lib/ai/prompts/producer.ts
@@ -61,13 +61,15 @@ You have tools that directly modify the workspace. USE THEM proactively:
 1. **generate_arrangement** - Use this whenever the user asks for chords, arrangement, song structure, or "pick for me". ALWAYS use the tool rather than describing chords in plain text. The tool creates real sections and chord progressions in the workspace instantly.
 2. **update_session** - Use this to change BPM, key, genre, or mood when the user asks or when you're picking everything.
 3. **add_track** - Use this to add instrument tracks when the user asks for a new instrument or when building arrangements.
-4. **suggest_lyrics** - Use this when the user wants lyrics, vocal ideas, or help with words for their song.
+4. **generate_notation** - Use this to write real melodic, bass, or rhythmic note content onto a track's piano roll. generate_arrangement only creates chord symbols/section metadata — it does NOT put playable notes anywhere. Always follow up with generate_notation to actually write notes so the piano roll and sheet music aren't empty.
+5. **suggest_lyrics** - Use this when the user wants lyrics, vocal ideas, or help with words for their song.
 
 ## CRITICAL RULES
 - When a user asks for chords, an arrangement, or says "build me something" — ALWAYS call generate_arrangement. Never just describe chords in text.
 - When picking a genre/mood/key/BPM — ALWAYS call update_session with the values you chose.
 - When the user asks for lyrics or vocal ideas — ALWAYS call suggest_lyrics with the actual lyrics. Never just describe them in text.
 - When the user asks to add an instrument or track — ALWAYS call add_track. Never just describe what they should add.
+- After creating sections with generate_arrangement and/or tracks with add_track, you MUST call generate_notation once per relevant track to write real note content. Chord symbols and arrangement metadata alone leave the piano roll empty — that is not acceptable. Use the exact track name you just created with add_track (or an existing track name) as trackName.
 - After using tools, give a SHORT summary of what you built and suggest what to do next.
 - Keep your text responses concise — the music speaks for itself.
 - Always end with a clear next action or question to keep momentum going.${


### PR DESCRIPTION
## Summary
- The producer chat's system prompt never mentioned the `generate_notation` tool, so "Build me a 4-section arrangement" only ever produced chord-symbol/section metadata via `generate_arrangement` — Piano Roll and Sheet Music stayed empty.
- Added `generate_notation` to the tool list and a CRITICAL RULE requiring the model to call it once per relevant track after creating sections/tracks.
- Fixed a client-side race where `generate_notation` could fire before a same-turn `add_track`'s session refresh resolved, silently misattributing notes to the wrong track.
- Extended the chord-fallback auto-placement to all tracks instead of just track 0.

## Test plan
- [x] tsc --noEmit
- [x] npm run lint
- [x] npm test (869 passed)
- [ ] Manual: ask the producer chat to build an arrangement and confirm notes appear in Piano Roll/Sheet Music for every track (recommend verifying on preview deploy)

Tack: UNB-54

🤖 Generated with Claude Code