### PR TITLE
[UNB-56] Wire Upgrade to Pro button to Stripe checkout

### DIFF
--- a/src/app/(app)/settings/billing/page.tsx
+++ b/src/app/(app)/settings/billing/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { getCurrentUser } from "@/lib/supabase/auth";
 import { ManageSubscriptionButton } from "./manage-subscription-button";
+import { UpgradeButton } from "./upgrade-button";
 
 const AI_CALL_LIMIT_FREE = 50;
 const AI_CALL_LIMIT_PRO = 1000;
@@ -135,13 +136,7 @@ export default async function BillingPage() {
             <p className="text-sm text-neutral-400">
               Upgrade to Pro for unlimited AI calls, priority support, and more.
             </p>
-            {/* TODO: replace href with real Stripe Checkout link when ready */}
-            <a
-              href="#"
-              className="inline-flex items-center rounded-lg bg-amber-500 px-5 py-2.5 text-sm font-semibold text-black transition-colors duration-200 hover:bg-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:ring-offset-2 focus:ring-offset-neutral-900"
-            >
-              Upgrade to Pro
-            </a>
+            <UpgradeButton />
           </div>
         )}
       </div>

--- a/src/app/(app)/settings/billing/upgrade-button.test.tsx
+++ b/src/app/(app)/settings/billing/upgrade-button.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UpgradeButton } from "./upgrade-button";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("UpgradeButton", () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, href: "" },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("redirects to the checkout URL on success", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ url: "https://checkout.stripe.com/session123" }),
+      }),
+    );
+
+    render(<UpgradeButton />);
+    await user.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
+
+    expect(fetch).toHaveBeenCalledWith("/api/billing/checkout", {
+      method: "POST",
+    });
+    await waitFor(() => {
+      expect(window.location.href).toBe(
+        "https://checkout.stripe.com/session123",
+      );
+    });
+  });
+
+  it("shows an inline error when Stripe is not configured (503)", async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({
+          error:
+            "Stripe is not configured. Set STRIPE_SECRET_KEY and STRIPE_PRO_PRICE_ID to enable billing.",
+        }),
+      }),
+    );
+
+    render(<UpgradeButton />);
+    await user.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
+
+    expect(
+      await screen.findByText(
+        "Stripe is not configured. Set STRIPE_SECRET_KEY and STRIPE_PRO_PRICE_ID to enable billing.",
+      ),
+    ).toBeInTheDocument();
+    expect(window.location.href).toBe("");
+  });
+
+  it("shows a loading state while the request is pending", async () => {
+    const user = userEvent.setup();
+    let resolveFetch: (value: unknown) => void = () => {};
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+      ),
+    );
+
+    render(<UpgradeButton />);
+    const button = screen.getByRole("button", { name: "Upgrade to Pro" });
+    await user.click(button);
+
+    expect(
+      screen.getByRole("button", { name: "Redirecting…" }),
+    ).toBeDisabled();
+
+    resolveFetch({
+      ok: true,
+      json: async () => ({ url: "https://checkout.stripe.com/session123" }),
+    });
+
+    await waitFor(() => {
+      expect(window.location.href).toBe(
+        "https://checkout.stripe.com/session123",
+      );
+    });
+  });
+});

--- a/src/app/(app)/settings/billing/upgrade-button.tsx
+++ b/src/app/(app)/settings/billing/upgrade-button.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useState } from "react";
+
+export function UpgradeButton() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleClick() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/billing/checkout", { method: "POST" });
+      const data = (await res.json()) as { url?: string; error?: string };
+      if (!res.ok || !data.url) {
+        setError(data.error ?? "Failed to start checkout.");
+        return;
+      }
+      window.location.href = data.url;
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <button
+        onClick={handleClick}
+        disabled={loading}
+        className="inline-flex items-center rounded-lg bg-amber-500 px-5 py-2.5 text-sm font-semibold text-black transition-colors duration-200 hover:bg-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-500/50 focus:ring-offset-2 focus:ring-offset-neutral-900 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {loading ? "Redirecting…" : "Upgrade to Pro"}
+      </button>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
"Upgrade to Pro" was a dead `<a href="#">` with a TODO comment. Added `UpgradeButton`, mirroring the existing `ManageSubscriptionButton` pattern: POSTs to `/api/billing/checkout`, redirects to the returned URL, shows an inline error on 503/failure, loading state while pending.

## Test plan
- [x] tsc --noEmit
- [x] npm run lint
- [x] npm test (869 passed; one transient run hit the pre-existing flaky offline-renderer test, clean on rerun)

Tack: UNB-56

🤖 Generated with Claude Code