### PR TITLE
[UNB-57] Add Billing nav link to Settings

### DIFF
--- a/src/components/layout/sidebar.test.ts
+++ b/src/components/layout/sidebar.test.ts
@@ -49,4 +49,12 @@ describe("Sidebar — mobile responsive classes (NAV3)", () => {
   it("My Sessions link navigates to /sessions", () => {
     expect(sidebarSrc).toContain('"/sessions"');
   });
+
+  it("Billing link navigates to /settings/billing", () => {
+    expect(sidebarSrc).toContain('"/settings/billing"');
+  });
+
+  it("Billing link has a visible label", () => {
+    expect(sidebarSrc).toContain('label="Billing"');
+  });
 });

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -66,6 +66,24 @@ function SettingsIcon() {
   );
 }
 
+function BillingIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="2" y="5" width="20" height="14" rx="2" />
+      <line x1="2" y1="10" x2="22" y2="10" />
+    </svg>
+  );
+}
+
 function CollapseIcon({ collapsed }: { collapsed: boolean }) {
   return (
     <svg
@@ -180,9 +198,15 @@ export function Sidebar({ mobileOpen = false, onMobileClose }: SidebarProps) {
       {/* Settings + logout + collapse */}
       <div className="border-t border-neutral-800/50 p-3">
         {collapsed ? (
-          <NavLink href="/settings" icon={<SettingsIcon />} label="" />
+          <>
+            <NavLink href="/settings" icon={<SettingsIcon />} label="" />
+            <NavLink href="/settings/billing" icon={<BillingIcon />} label="" />
+          </>
         ) : (
-          <NavLink href="/settings" icon={<SettingsIcon />} label="Settings" />
+          <>
+            <NavLink href="/settings" icon={<SettingsIcon />} label="Settings" />
+            <NavLink href="/settings/billing" icon={<BillingIcon />} label="Billing" />
+          </>
         )}
         <button
           onClick={async () => {


### PR DESCRIPTION
## Summary
/settings/billing was fully functional but had zero navigation entry point. Added a Billing link to the sidebar (collapsed + expanded states) alongside the existing Settings link.

## Test plan
- [x] tsc --noEmit
- [x] npm run lint
- [x] npm test (868 passed)

Tack: UNB-57

🤖 Generated with Claude Code