### PR TITLE
[UNB-58] Disable MIDI export when there are no notes

### DIFF
--- a/src/app/api/midi/export/route.test.ts
+++ b/src/app/api/midi/export/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import type { Note, Track } from "@/lib/music/types";
+import { POST } from "./route";
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "track-1",
+    sessionId: "sess-1",
+    name: "Piano",
+    instrument: "piano",
+    volume: 1,
+    pan: 0,
+    muted: false,
+    solo: false,
+    color: "#fff",
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: "note-1",
+    trackId: "track-1",
+    pitch: "C4",
+    startTick: 0,
+    durationTicks: 480,
+    velocity: 100,
+    ...overrides,
+  };
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/midi/export", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/midi/export", () => {
+  it("returns 400 when no tracks are provided", async () => {
+    const res = await POST(makeRequest({ tracks: [], notes: [] }) as never);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No tracks provided" });
+  });
+
+  it("returns 400 when notes are empty after filtering to selected tracks", async () => {
+    const res = await POST(
+      makeRequest({ tracks: [makeTrack()], notes: [] }) as never,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No notes to export" });
+  });
+
+  it("returns 400 when notes exist but none belong to the selected tracks", async () => {
+    const res = await POST(
+      makeRequest({
+        tracks: [makeTrack()],
+        notes: [makeNote({ trackId: "other-track" })],
+      }) as never,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "No notes to export" });
+  });
+
+  it("exports a MIDI file (200) when tracks and notes are present", async () => {
+    const res = await POST(
+      makeRequest({
+        tracks: [makeTrack()],
+        notes: [makeNote()],
+      }) as never,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("audio/midi");
+    const buf = await res.arrayBuffer();
+    expect(buf.byteLength).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/midi/export/route.ts
+++ b/src/app/api/midi/export/route.ts
@@ -77,6 +77,13 @@ export async function POST(request: Request): Promise<Response> {
     const selectedTrackIds = new Set(filteredTracks.map((t) => t.id));
     notes = notes.filter((n) => selectedTrackIds.has(n.trackId));
 
+    if (notes.length === 0) {
+      return NextResponse.json(
+        { error: "No notes to export" },
+        { status: 400 },
+      );
+    }
+
     const midiBytes = exportToMidi(filteredTracks, notes, bpm);
 
     const filename = body.sessionId

--- a/src/components/export/export-dialog.test.tsx
+++ b/src/components/export/export-dialog.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import { ExportDialog } from "./export-dialog";
+import { ToastProvider } from "@/components/ui/toast-provider";
+import type { Note, Session, Track } from "@/lib/music/types";
+
+const { useSessionContextMock } = vi.hoisted(() => ({
+  useSessionContextMock: vi.fn(),
+}));
+
+vi.mock("@/lib/session/context", () => ({
+  useSessionContext: useSessionContextMock,
+}));
+
+// jsdom does not implement <dialog> modal behavior.
+if (!HTMLDialogElement.prototype.showModal) {
+  HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+    this.setAttribute("open", "");
+  };
+  HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+    this.removeAttribute("open");
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  useSessionContextMock.mockReset();
+});
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  const now = new Date().toISOString();
+  return {
+    id: "sess-1",
+    userId: "user-1",
+    title: "Midnight Jam",
+    status: "active",
+    bpm: 120,
+    keySignature: "C major",
+    timeSignature: "4/4",
+    createdAt: now,
+    updatedAt: now,
+    lastActiveAt: now,
+    ...overrides,
+  };
+}
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: "note-1",
+    trackId: "track-1",
+    pitch: "C4",
+    startTick: 0,
+    durationTicks: 480,
+    velocity: 100,
+    ...overrides,
+  };
+}
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "track-1",
+    sessionId: "sess-1",
+    name: "Piano",
+    instrument: "piano",
+    volume: 1,
+    pan: 0,
+    muted: false,
+    solo: false,
+    color: "#fff",
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+function setSessionContext(notes: Note[], tracks: Track[] = [makeTrack()]) {
+  useSessionContextMock.mockReturnValue({
+    session: makeSession(),
+    notes,
+    tracks,
+    sections: [],
+    setNotes: vi.fn(),
+    addSections: vi.fn(),
+    deleteSection: vi.fn(),
+    clearSections: vi.fn(),
+    updateSection: vi.fn(),
+    updateTrack: vi.fn(),
+    isLoading: false,
+    error: null,
+    updateSession: vi.fn(),
+    refreshSession: vi.fn(),
+  });
+}
+
+function renderDialog() {
+  return render(
+    <ToastProvider>
+      <ExportDialog open sessionId="sess-1" onClose={vi.fn()} />
+    </ToastProvider>,
+  );
+}
+
+/** Scope queries to the "MIDI File" export section, since the MusicXML and
+ * WAV sections render the same "No notes to export" label when notes are empty. */
+function getMidiSection(): HTMLElement {
+  const heading = screen.getByRole("heading", { name: "MIDI File" });
+  const section = heading.closest("div.rounded-lg");
+  if (!section) throw new Error("Could not find MIDI export section");
+  return section as HTMLElement;
+}
+
+describe("ExportDialog MIDI export button", () => {
+  it("disables the MIDI export button and shows 'No notes to export' when there are no notes", () => {
+    setSessionContext([]);
+    renderDialog();
+
+    const button = within(getMidiSection()).getByRole("button", {
+      name: "No notes to export",
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it("enables the MIDI export button and shows 'Export MIDI' when notes exist", () => {
+    setSessionContext([makeNote()]);
+    renderDialog();
+
+    const button = within(getMidiSection()).getByRole("button", {
+      name: "Export MIDI",
+    });
+    expect(button).toBeEnabled();
+  });
+});

--- a/src/components/export/export-dialog.tsx
+++ b/src/components/export/export-dialog.tsx
@@ -241,9 +241,10 @@ export function ExportDialog({
               variant="primary"
               size="sm"
               onClick={handleMidiExport}
+              disabled={notes.length === 0}
               className="w-full"
             >
-              Export MIDI
+              {notes.length === 0 ? "No notes to export" : "Export MIDI"}
             </Button>
           )}
 


### PR DESCRIPTION
## Summary
MusicXML and WAV export already disabled with "No notes to export" when the session has zero notes; MIDI export had no such guard and would silently produce a valid-but-empty .mid file with a false "Export complete" state. Added the same client-side disable + a server-side 400 for defense-in-depth.

## Test plan
- [x] tsc --noEmit
- [x] npm run lint
- [x] npm test (872 passed, incl. new coverage for both the button state and the route's 400)

Tack: UNB-58

🤖 Generated with Claude Code