### PR TITLE
[UNB-59] Fix chat message list layout squeeze after AI responses

### DIFF
--- a/src/components/chat/chat-panel.tsx
+++ b/src/components/chat/chat-panel.tsx
@@ -141,54 +141,62 @@ export function ChatPanel({
       <ChatErrorBanner errorType={chatError} />
 
       {/* Messages */}
-      <MessageList messages={messages} isStreaming={isStreaming} className="flex-1" />
+      <MessageList
+        messages={messages}
+        isStreaming={isStreaming}
+        className="flex-1"
+        footer={
+          <>
+            {/* Regenerate button — shown when last message is from assistant and idle */}
+            {!isStreaming &&
+              messages.length > 0 &&
+              messages[messages.length - 1].role === "assistant" && (
+                <div className="flex justify-start pb-1 pt-0">
+                  <button
+                    onClick={regenerate}
+                    className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-neutral-500 transition-colors hover:bg-neutral-800 hover:text-neutral-300"
+                    aria-label="Regenerate last response"
+                  >
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                      <path d="M3 3v5h5" />
+                    </svg>
+                    Regenerate
+                  </button>
+                </div>
+              )}
 
-      {/* Regenerate button — shown when last message is from assistant and idle */}
-      {!isStreaming &&
-        messages.length > 0 &&
-        messages[messages.length - 1].role === "assistant" && (
-          <div className="flex justify-start px-4 pb-1 pt-0">
-            <button
-              onClick={regenerate}
-              className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-neutral-500 transition-colors hover:bg-neutral-800 hover:text-neutral-300"
-              aria-label="Regenerate last response"
-            >
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
-                <path d="M3 3v5h5" />
-              </svg>
-              Regenerate
-            </button>
-          </div>
-        )}
+            {/* Suggestions */}
+            {activeSuggestions.length > 0 && !isStreaming && (
+              <SuggestionChips
+                suggestions={activeSuggestions}
+                onSelect={handleSuggestionSelect}
+                className="px-0"
+              />
+            )}
 
-      {/* Suggestions */}
-      {activeSuggestions.length > 0 && !isStreaming && (
-        <SuggestionChips
-          suggestions={activeSuggestions}
-          onSelect={handleSuggestionSelect}
-        />
-      )}
-
-      {/* Just Pick Button - always available when chat is idle */}
-      {messages.length > 0 && !isStreaming && (
-        <div className="flex justify-center px-4 py-2">
-          <JustPickButton
-            context="what to do next"
-            onPick={handleJustPick}
-            disabled={isStreaming}
-          />
-        </div>
-      )}
+            {/* Just Pick Button - always available when chat is idle */}
+            {messages.length > 0 && !isStreaming && (
+              <div className="flex justify-center py-2">
+                <JustPickButton
+                  context="what to do next"
+                  onPick={handleJustPick}
+                  disabled={isStreaming}
+                />
+              </div>
+            )}
+          </>
+        }
+      />
 
       {/* Input */}
       <ChatInput onSend={sendMessage} disabled={isStreaming} />

--- a/src/components/chat/message-list.test.tsx
+++ b/src/components/chat/message-list.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { MessageList } from "./message-list";
+import type { ChatMessage } from "@/lib/music/types";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: "msg-1",
+    sessionId: "sess-1",
+    role: "assistant",
+    content: "Here's your chord progression.",
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("MessageList", () => {
+  beforeEach(() => {
+    // jsdom does not implement scrollIntoView; stub it so the auto-scroll
+    // effect can run without throwing.
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("renders footer content inside the scrollable container, after the messages", () => {
+    render(
+      <MessageList
+        messages={[makeMessage()]}
+        footer={<div data-testid="footer">Quick actions</div>}
+      />,
+    );
+
+    const message = screen.getByText("Here's your chord progression.");
+    const footer = screen.getByTestId("footer");
+
+    expect(footer).toBeInTheDocument();
+    // Footer must live in the same scrollable container as the messages,
+    // not as a fixed sibling outside of it.
+    expect(message.closest(".overflow-y-auto")).toBe(
+      footer.closest(".overflow-y-auto"),
+    );
+
+    // Footer should come after the message in DOM order (scrolling to the
+    // bottom of the container should reveal it).
+    const position = message.compareDocumentPosition(footer);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("does not render the footer in the empty state", () => {
+    render(
+      <MessageList
+        messages={[]}
+        footer={<div data-testid="footer">Quick actions</div>}
+      />,
+    );
+
+    expect(screen.queryByTestId("footer")).not.toBeInTheDocument();
+    expect(screen.getByText("What are you hearing?")).toBeInTheDocument();
+  });
+
+  it("auto-scrolls to the bottom sentinel when a new message arrives", () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+    const { rerender } = render(<MessageList messages={[makeMessage()]} />);
+    scrollIntoViewMock.mockClear();
+
+    rerender(
+      <MessageList
+        messages={[makeMessage(), makeMessage({ id: "msg-2", role: "user", content: "Nice!" })]}
+      />,
+    );
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "end",
+    });
+  });
+});

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, type ReactNode } from "react";
 import { cn } from "@/lib/utils/cn";
 import type { ChatMessage } from "@/lib/music/types";
 import { MessageBubble } from "./message-bubble";
@@ -9,6 +9,8 @@ interface MessageListProps {
   messages: ChatMessage[];
   isStreaming?: boolean;
   className?: string;
+  /** Trailing content rendered inside the scroll container, after the last message. */
+  footer?: ReactNode;
 }
 
 /** Threshold (px) to decide if the user is "near the bottom" of the scroll container. */
@@ -26,7 +28,7 @@ function TypingIndicator() {
   );
 }
 
-export function MessageList({ messages, isStreaming = false, className }: MessageListProps) {
+export function MessageList({ messages, isStreaming = false, className, footer }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   /** Whether the user is near the bottom (should auto-scroll). */
@@ -43,10 +45,7 @@ export function MessageList({ messages, isStreaming = false, className }: Messag
   /** Scroll to the bottom if user is near it. */
   const scrollToBottomIfNeeded = useCallback(() => {
     if (!isNearBottomRef.current) return;
-    const el = containerRef.current;
-    if (el) {
-      el.scrollTop = el.scrollHeight;
-    }
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, []);
 
   // Track user scroll position
@@ -125,6 +124,7 @@ export function MessageList({ messages, isStreaming = false, className }: Messag
         <MessageBubble key={message.id} message={message} />
       ))}
       {showTypingIndicator && <TypingIndicator />}
+      {footer}
       <div ref={bottomRef} />
     </div>
   );


### PR DESCRIPTION
## Summary
MessageList's own scroll-to-bottom logic was already correct. The real bug: the Regenerate button, suggestion chips, and Just Pick button rendered as fixed siblings below MessageList, outside its scroll container. Right after a response, those three UI blocks together consume a large chunk of fixed vertical space, squeezing the message viewport down to a tiny strip — this is what read as "chat doesn't show new messages."

Moved them into a `footer` prop rendered inside MessageList's scrollable container so they scroll with the conversation instead of permanently reserving layout space. Also wired the previously-unused `bottomRef` via `scrollIntoView` for more robust auto-scroll.

## Test plan
- [x] tsc --noEmit
- [x] npm run lint
- [x] npm test (869 passed, incl. 3 new tests for footer placement + auto-scroll)

Tack: UNB-59

🤖 Generated with Claude Code