### PR TITLE
[UNB-60] Skip redundant OSMD renders causing multi-second freezes

### DIFF
--- a/src/components/sheet-music/sheet-music-view.tsx
+++ b/src/components/sheet-music/sheet-music-view.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils/cn";
 import type { Note, Track } from "@/lib/music/types";
 import { exportToMusicXML } from "@/lib/musicxml/writer";
+import { computeContentSignature } from "@/lib/music/content-signature";
 
 export interface SheetMusicViewProps {
   tracks: Track[];
@@ -44,6 +45,13 @@ export function SheetMusicView({
   const elemToNoteRef = useRef<Map<Element, Note>>(new Map());
   const noteIdToElemRef = useRef<Map<string, Element>>(new Map());
   const selectedNoteIdRef = useRef<string | null | undefined>(selectedNoteId);
+  // Signature of the score content (tracks/notes/bpm/key/time-sig) from the
+  // last successful full render — lets renderScore() skip the expensive
+  // exportToMusicXML/osmd.load/osmd.render pipeline when nothing that
+  // affects the rendered score actually changed (e.g. a parent re-render
+  // handing down a new-but-identical `notes` array reference).
+  const lastRenderedSignatureRef = useRef<string | null>(null);
+  const lastRenderedZoomRef = useRef<number | null>(null);
 
   // Lazily import OSMD (it's a large library, only load when needed)
   useEffect(() => {
@@ -58,6 +66,13 @@ export function SheetMusicView({
         if (cancelled || !containerRef.current) return;
 
         const osmd = new OpenSheetMusicDisplay(containerRef.current, {
+          // opensheetmusicdisplay@1.9.9's autoResize only listens for
+          // window "resize" events (200ms debounced) — it does not use a
+          // ResizeObserver on the container, so calling osmd.render() here
+          // (which can change the container's content height) does not
+          // itself dispatch a window resize and cannot create a
+          // render->resize->render feedback loop. Safe to leave enabled so
+          // the score re-flows if the browser window is resized.
           autoResize: true,
           backend: "svg",
           drawTitle: false,
@@ -127,9 +142,12 @@ export function SheetMusicView({
     const notesSorted = [...notes].sort((a, b) => a.startTick - b.startTick);
     const assigned = new Set<string>();
 
+    // Computed once outside the loop: the svg's position doesn't change
+    // across iterations, so re-querying it per-element was pure waste.
+    const svgRect = svg.getBoundingClientRect();
+
     for (const elem of stavenotes) {
       const rect = elem.getBoundingClientRect();
-      const svgRect = svg.getBoundingClientRect();
       const relX = rect.left + rect.width / 2 - svgRect.left;
       const estimatedTick = (relX / svgWidth) * maxTick;
 
@@ -157,17 +175,31 @@ export function SheetMusicView({
     const osmd = osmdRef.current;
     if (!osmd || tracks.length === 0) return;
 
-    try {
-      const musicxml = exportToMusicXML(tracks, notes, bpm, {
-        keySignature,
-        timeSignature,
-      });
+    const signature = computeContentSignature(tracks, notes, bpm, keySignature, timeSignature);
+    const contentChanged = signature !== lastRenderedSignatureRef.current;
+    const zoomChanged = zoom !== lastRenderedZoomRef.current;
 
-      await osmd.load(musicxml);
+    // Nothing that affects the rendered score changed (e.g. a parent
+    // re-render handed down new-but-identical tracks/notes references) —
+    // skip the expensive export/load/render pipeline entirely.
+    if (!contentChanged && !zoomChanged) return;
+
+    try {
+      if (contentChanged) {
+        const musicxml = exportToMusicXML(tracks, notes, bpm, {
+          keySignature,
+          timeSignature,
+        });
+        await osmd.load(musicxml);
+      }
       osmd.zoom = zoom;
       osmd.render();
+      lastRenderedSignatureRef.current = signature;
+      lastRenderedZoomRef.current = zoom;
       setError(null);
-      buildNoteMap();
+      if (contentChanged) {
+        buildNoteMap();
+      }
       applyHighlight(selectedNoteIdRef.current);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to render score");

--- a/src/lib/music/content-signature.test.ts
+++ b/src/lib/music/content-signature.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { computeContentSignature } from "./content-signature";
+import type { Note, Track } from "@/lib/music/types";
+
+function makeTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "track-1",
+    sessionId: "session-1",
+    name: "Piano",
+    instrument: "piano",
+    volume: 1,
+    pan: 0,
+    muted: false,
+    solo: false,
+    color: "#fff",
+    sortOrder: 0,
+    ...overrides,
+  };
+}
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  return {
+    id: "note-1",
+    trackId: "track-1",
+    pitch: "C4",
+    startTick: 0,
+    durationTicks: 480,
+    velocity: 100,
+    ...overrides,
+  };
+}
+
+describe("computeContentSignature", () => {
+  it("produces the same signature for a new array reference with identical content", () => {
+    const tracks = [makeTrack()];
+    const notes = [makeNote()];
+
+    const sigA = computeContentSignature(tracks, notes, 120, "C major", "4/4");
+    const sigB = computeContentSignature([...tracks], [...notes], 120, "C major", "4/4");
+
+    expect(sigA).toBe(sigB);
+  });
+
+  it("changes when a note's pitch changes", () => {
+    const tracks = [makeTrack()];
+    const notesA = [makeNote({ pitch: "C4" })];
+    const notesB = [makeNote({ pitch: "D4" })];
+
+    const sigA = computeContentSignature(tracks, notesA, 120, "C major", "4/4");
+    const sigB = computeContentSignature(tracks, notesB, 120, "C major", "4/4");
+
+    expect(sigA).not.toBe(sigB);
+  });
+
+  it("changes when a note's startTick or durationTicks changes", () => {
+    const tracks = [makeTrack()];
+    const base = computeContentSignature(tracks, [makeNote()], 120, "C major", "4/4");
+
+    expect(computeContentSignature(tracks, [makeNote({ startTick: 480 })], 120, "C major", "4/4")).not.toBe(base);
+    expect(computeContentSignature(tracks, [makeNote({ durationTicks: 240 })], 120, "C major", "4/4")).not.toBe(base);
+  });
+
+  it("changes when notes are added or removed", () => {
+    const tracks = [makeTrack()];
+    const sigOne = computeContentSignature(tracks, [makeNote()], 120, "C major", "4/4");
+    const sigTwo = computeContentSignature(
+      tracks,
+      [makeNote(), makeNote({ id: "note-2", startTick: 480 })],
+      120,
+      "C major",
+      "4/4",
+    );
+
+    expect(sigOne).not.toBe(sigTwo);
+  });
+
+  it("changes when a track's instrument changes", () => {
+    const notes = [makeNote()];
+    const sigA = computeContentSignature([makeTrack({ instrument: "piano" })], notes, 120, "C major", "4/4");
+    const sigB = computeContentSignature([makeTrack({ instrument: "bass_electric" })], notes, 120, "C major", "4/4");
+
+    expect(sigA).not.toBe(sigB);
+  });
+
+  it("changes when bpm, key signature, or time signature changes", () => {
+    const tracks = [makeTrack()];
+    const notes = [makeNote()];
+    const base = computeContentSignature(tracks, notes, 120, "C major", "4/4");
+
+    expect(computeContentSignature(tracks, notes, 140, "C major", "4/4")).not.toBe(base);
+    expect(computeContentSignature(tracks, notes, 120, "G major", "4/4")).not.toBe(base);
+    expect(computeContentSignature(tracks, notes, 120, "C major", "3/4")).not.toBe(base);
+  });
+
+  it("is order-sensitive for tracks and notes", () => {
+    const trackA = makeTrack({ id: "a" });
+    const trackB = makeTrack({ id: "b" });
+    const noteA = makeNote({ id: "a" });
+    const noteB = makeNote({ id: "b", startTick: 480 });
+
+    const sig1 = computeContentSignature([trackA, trackB], [noteA, noteB], 120, "C major", "4/4");
+    const sig2 = computeContentSignature([trackB, trackA], [noteB, noteA], 120, "C major", "4/4");
+
+    expect(sig1).not.toBe(sig2);
+  });
+});

--- a/src/lib/music/content-signature.ts
+++ b/src/lib/music/content-signature.ts
@@ -1,0 +1,24 @@
+/**
+ * Build a lightweight signature of the musically-relevant fields of tracks/notes
+ * (plus the score-level attributes baked into the exported MusicXML: bpm, key
+ * signature, time signature). Used to skip expensive re-renders (MusicXML
+ * export + OSMD load + OSMD render) when nothing that affects the rendered
+ * score has actually changed, even if the `tracks`/`notes` array references
+ * themselves are new (e.g. re-created by a parent/store on unrelated updates).
+ */
+
+import type { Note, Track } from "@/lib/music/types";
+
+export function computeContentSignature(
+  tracks: Track[],
+  notes: Note[],
+  bpm: number,
+  keySignature: string,
+  timeSignature: string,
+): string {
+  const trackSig = tracks.map((t) => `${t.id}:${t.instrument}:${t.name}`).join("|");
+  const noteSig = notes
+    .map((n) => `${n.id}:${n.trackId}:${n.pitch}:${n.startTick}:${n.durationTicks}:${n.velocity}`)
+    .join("|");
+  return `${trackSig}#${noteSig}#${bpm}#${keySignature}#${timeSignature}`;
+}


### PR DESCRIPTION
## Summary
Investigated a reproduced ~20-30s main-thread freeze on Sheet Music panel toggle / chat-triggered notation generation. Ruled out an OSMD `autoResize` feedback loop (this version debounces on window resize only, no ResizeObserver). Actual driver: `renderScore()` re-ran the full `exportToMusicXML → osmd.load → osmd.render` pipeline on any reference change, including new-but-identical `notes`/`tracks` arrays from unrelated re-renders. `buildNoteMap()` also recomputed `svg.getBoundingClientRect()` on every loop iteration.

Added a content-signature guard so the expensive pipeline only runs when musical content actually changed, and hoisted the redundant rect read out of the per-note loop.

## Test plan
- [x] tsc --noEmit
- [x] npm run lint
- [x] npm test (873 passed, incl. 7 new content-signature tests)
- [ ] Manual: confirm no visible freeze toggling Sheet Music on a populated session (recommend verifying on preview deploy)

Tack: UNB-60

🤖 Generated with Claude Code