### PR TITLE
[UNB-61] Themed scrollbar on chat textarea and message list

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  // Next.js dev tools indicator (bottom-left by default) sits directly over
+  // the chat input, which lives flush to the bottom-left of the viewport on
+  // mobile — it was mistaken for an app bug during QA. Dev-mode only, no
+  // effect on production, but disabling it avoids the false positive.
+  devIndicators: false,
 };
 
 export default nextConfig;

--- a/src/components/chat/chat-input.tsx
+++ b/src/components/chat/chat-input.tsx
@@ -69,6 +69,10 @@ export function ChatInput({ onSend, disabled = false, className }: ChatInputProp
             "disabled:cursor-not-allowed disabled:opacity-50",
             "transition-colors duration-300",
             "max-h-40",
+            "[&::-webkit-scrollbar]:w-1.5",
+            "[&::-webkit-scrollbar-track]:bg-transparent",
+            "[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-neutral-700",
+            "[&::-webkit-scrollbar-thumb]:hover:bg-neutral-500",
           )}
         />
         </FirstUseTooltip>

--- a/src/components/chat/message-list.tsx
+++ b/src/components/chat/message-list.tsx
@@ -117,6 +117,10 @@ export function MessageList({ messages, isStreaming = false, className, footer }
       ref={containerRef}
       className={cn(
         "flex flex-1 flex-col gap-3 overflow-y-auto px-4 py-4",
+        "[&::-webkit-scrollbar]:w-1.5",
+        "[&::-webkit-scrollbar-track]:bg-transparent",
+        "[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-neutral-700",
+        "[&::-webkit-scrollbar-thumb]:hover:bg-neutral-500",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
Chat textarea and message list both fell back to the native OS scrollbar once content exceeded their max height. Applied the same themed webkit-scrollbar classes already used in `scroll-area.tsx`.

Also investigated a reported icon overlapping typed text — traced it to Next.js's dev-mode indicator (bottom-left by default, dev-only, no production impact), disabled it in `next.config.ts` to remove the false-positive during local testing. `FirstUseTooltip` was ruled out as the cause (its bubble positions clear of the textarea).

## Test plan
- [x] tsc --noEmit
- [x] npm run lint
- [x] npm test (908 passed — includes tests from stories 9/10 already merged to main)
- [x] Verified live: forced textarea past max-height, confirmed themed scrollbar renders instead of native

Tack: UNB-61

🤖 Generated with Claude Code