### PR TITLE
[UNB-62] Size dashboard skeleton grid from last-known session count

### DIFF
--- a/src/components/session/session-list.test.tsx
+++ b/src/components/session/session-list.test.tsx
@@ -7,6 +7,7 @@ import type { Session } from "@/lib/music/types";
 
 afterEach(() => {
   cleanup();
+  localStorage.clear();
 });
 
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -28,15 +29,62 @@ function makeSession(overrides: Partial<Session> = {}): Session {
   };
 }
 
+const LAST_SESSION_COUNT_KEY = "unbottle:last-session-count";
+
+function skeletonCardCount(container: HTMLElement): number {
+  // Each skeleton card renders 4 Skeleton elements (title, 2 tags, date)
+  return container.querySelectorAll(".animate-pulse").length / 4;
+}
+
 describe("SessionList", () => {
   it("shows skeleton placeholders while loading", () => {
     const { container } = render(
       <SessionList sessions={[]} isLoading={true} />,
     );
-    // 6 skeleton cards in the loading state
     expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
       0,
     );
+  });
+
+  it("defaults to 3 skeleton cards on first-ever load with no cached count", () => {
+    const { container } = render(
+      <SessionList sessions={[]} isLoading={true} />,
+    );
+    expect(skeletonCardCount(container)).toBe(3);
+  });
+
+  it("uses the cached session count to size the skeleton grid", () => {
+    localStorage.setItem(LAST_SESSION_COUNT_KEY, "2");
+    const { container } = render(
+      <SessionList sessions={[]} isLoading={true} />,
+    );
+    expect(skeletonCardCount(container)).toBe(2);
+  });
+
+  it("clamps the cached count to a max of 6 skeleton cards", () => {
+    localStorage.setItem(LAST_SESSION_COUNT_KEY, "20");
+    const { container } = render(
+      <SessionList sessions={[]} isLoading={true} />,
+    );
+    expect(skeletonCardCount(container)).toBe(6);
+  });
+
+  it("clamps the cached count to a min of 1 skeleton card", () => {
+    localStorage.setItem(LAST_SESSION_COUNT_KEY, "0");
+    const { container } = render(
+      <SessionList sessions={[]} isLoading={true} />,
+    );
+    expect(skeletonCardCount(container)).toBe(1);
+  });
+
+  it("caches the session count once sessions load, for use on the next loading render", () => {
+    const sessions = [
+      makeSession({ id: "a", title: "Alpha" }),
+      makeSession({ id: "b", title: "Beta" }),
+    ];
+    render(<SessionList sessions={sessions} isLoading={false} />);
+
+    expect(localStorage.getItem(LAST_SESSION_COUNT_KEY)).toBe("2");
   });
 
   it("shows the empty state when there are no sessions", () => {

--- a/src/components/session/session-list.tsx
+++ b/src/components/session/session-list.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import type { Session } from "@/lib/music/types";
 import { SessionCard } from "./session-card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -11,11 +12,49 @@ interface SessionListProps {
   onDelete?: (id: string) => Promise<void>;
 }
 
+const LAST_SESSION_COUNT_KEY = "unbottle:last-session-count";
+const MIN_SKELETON_COUNT = 1;
+const MAX_SKELETON_COUNT = 6;
+const DEFAULT_SKELETON_COUNT = 3;
+
+function clampSkeletonCount(count: number): number {
+  return Math.min(MAX_SKELETON_COUNT, Math.max(MIN_SKELETON_COUNT, count));
+}
+
+function readLastSessionCount(): number {
+  if (typeof window === "undefined") return DEFAULT_SKELETON_COUNT;
+  try {
+    const raw = localStorage.getItem(LAST_SESSION_COUNT_KEY);
+    const parsed = raw ? parseInt(raw, 10) : NaN;
+    return Number.isNaN(parsed) ? DEFAULT_SKELETON_COUNT : clampSkeletonCount(parsed);
+  } catch {
+    return DEFAULT_SKELETON_COUNT;
+  }
+}
+
+function writeLastSessionCount(count: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(LAST_SESSION_COUNT_KEY, String(count));
+  } catch {
+    // Storage full — not critical
+  }
+}
+
 export function SessionList({ sessions, isLoading, onRename, onDelete }: SessionListProps) {
+  const [skeletonCount, setSkeletonCount] = useState(readLastSessionCount);
+
+  useEffect(() => {
+    if (!isLoading && sessions.length > 0) {
+      writeLastSessionCount(sessions.length);
+      setSkeletonCount(clampSkeletonCount(sessions.length));
+    }
+  }, [isLoading, sessions.length]);
+
   if (isLoading) {
     return (
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, i) => (
+        {Array.from({ length: skeletonCount }).map((_, i) => (
           <div
             key={i}
             className="flex flex-col rounded-xl border border-neutral-800 bg-neutral-900/50 p-4"


### PR DESCRIPTION
## Summary
SessionList always rendered exactly 6 skeleton cards while loading, regardless of the user's actual session count — a jarring collapse for anyone with 1-2 sessions. Caches the last-seen count in localStorage and sizes the skeleton grid from it (clamped 1-6), falling back to 3 on first-ever load.

## Test plan
- [x] tsc --noEmit
- [x] npm run lint
- [x] npm test (871 passed, incl. 5 new tests)

Tack: UNB-62

🤖 Generated with Claude Code