### PR TITLE
fix(tooltip): add clearance for top-positioned bubbles

### DIFF
--- a/src/components/ui/first-use-tooltip.tsx
+++ b/src/components/ui/first-use-tooltip.tsx
@@ -19,7 +19,7 @@ const POSITION_CLASSES: Record<
   { bubble: string; arrow: string }
 > = {
   top: {
-    bubble: "bottom-full mb-2 left-1/2 -translate-x-1/2",
+    bubble: "bottom-full mb-4 left-1/2 -translate-x-1/2",
     arrow:
       "absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-amber-500",
   },


### PR DESCRIPTION
## Summary
Following up on a QA finding that couldn't be reproduced in-session (the test account had already dismissed first-use tooltips). Reset the account's dismissal state (both localStorage and the Supabase `profiles.preferences` fallback) and reproduced live: the chat input's first-use tooltip renders close enough to the suggestion-chip row above it that its edge overlaps.

Increased the "top" position's bottom margin (8px → 16px) in the shared `FirstUseTooltip` component for more reliable clearance. This affects all 4 call sites using `position="top"` (chat input, capture record button, piano roll, export) — pure spacing increase, no other behavior change.

## Test plan
- [x] tsc --noEmit
- [x] npm run lint
- [x] Verified live on production: reset tooltip-dismissal state, confirmed the overlap, will re-verify post-deploy

🤖 Generated with Claude Code