### PR TITLE
fix(db): apply the 5 migrations prod never had, close RLS holes (UNB-37)

### DIFF
--- a/src/app/api/share/[id]/verify/route.ts
+++ b/src/app/api/share/[id]/verify/route.ts
@@ -6,11 +6,22 @@
  * No auth required — public endpoint.
  */
 
-import { createClient } from "@/lib/supabase/server";
-import { getSessionBySlug } from "@/lib/supabase/db";
+import { createClient as createServiceClient } from "@supabase/supabase-js";
 import { verifySharePassword } from "@/lib/share/password";
 
 export const dynamic = "force-dynamic";
+
+/**
+ * Reads share_password_hash, which `anon` deliberately has no column grant on
+ * (20260512000100). The comparison has to happen server-side; the hash must
+ * never reach the client.
+ */
+function getServiceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return null;
+  return createServiceClient(url, key, { auth: { persistSession: false } });
+}
 
 export async function POST(
   request: Request,
@@ -19,9 +30,13 @@ export async function POST(
   const { id } = await params;
 
   try {
-    const client = await createClient();
+    const client = getServiceClient();
+    if (!client) {
+      return Response.json({ error: "Not found" }, { status: 404 });
+    }
 
-    // Fetch the session (by slug) including password_hash
+    // This client bypasses RLS, so is_public is the only gate on the row -- it
+    // must be checked before anything is returned or compared.
     const { data, error } = await client
       .from("sessions")
       .select("id, is_public, share_password_hash")
@@ -43,8 +58,8 @@ export async function POST(
 
     const valid = await verifySharePassword(password, data.share_password_hash);
     return Response.json({ valid });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Internal server error";
-    return Response.json({ error: message }, { status: 500 });
+  } catch {
+    // Don't echo the DB error: this endpoint is public and unauthenticated.
+    return Response.json({ error: "Internal server error" }, { status: 500 });
   }
 }

--- a/src/app/share/[id]/page.tsx
+++ b/src/app/share/[id]/page.tsx
@@ -21,10 +21,11 @@ async function fetchShareData(slug: string): Promise<ShareData | null> {
     try {
       const client = await createClient();
 
-      // Fetch session + password_hash in one query
+      // has_share_password, not share_password_hash: anon has no column grant on
+      // the hash, and this page renders for signed-out visitors.
       const { data: row, error } = await client
         .from("sessions")
-        .select("*, share_password_hash")
+        .select("is_public, has_share_password")
         .eq("share_slug", slug)
         .maybeSingle();
 
@@ -49,7 +50,7 @@ async function fetchShareData(slug: string): Promise<ShareData | null> {
       return {
         session,
         audioUrl,
-        passwordProtected: Boolean(row.share_password_hash),
+        passwordProtected: Boolean(row.has_share_password),
       };
     } catch {
       return null;

--- a/src/lib/supabase/db.ts
+++ b/src/lib/supabase/db.ts
@@ -80,6 +80,18 @@ export async function getSession(
 }
 
 /**
+ * Columns readable by a signed-out share viewer. `anon` holds a column-level
+ * grant on sessions rather than a table-level one (see
+ * 20260512000100_add_share_link_password) so share_password_hash stays secret,
+ * which means `select("*")` returns "permission denied for table sessions" for
+ * anon. Any column added to sessions must be added both to that GRANT and here.
+ */
+const SHARE_VIEWER_COLUMNS =
+  "id, user_id, title, description, status, bpm, key_signature, time_signature, " +
+  "genre, mood, parent_branch_id, created_at, updated_at, last_active_at, " +
+  "share_slug, is_public, has_share_password";
+
+/**
  * Get a session by its share slug. Returns null if not found.
  */
 export async function getSessionBySlug(
@@ -88,13 +100,13 @@ export async function getSessionBySlug(
 ): Promise<Session | null> {
   const { data, error } = await client
     .from("sessions")
-    .select("*")
+    .select(SHARE_VIEWER_COLUMNS)
     .eq("share_slug", slug)
     .maybeSingle();
 
   if (error) throw error;
   if (!data) return null;
-  return mapSessionRow(data as SessionRow);
+  return mapSessionRow(data as unknown as SessionRow);
 }
 
 /**

--- a/supabase/migrations/20260508120000_add_share_slug.sql
+++ b/supabase/migrations/20260508120000_add_share_slug.sql
@@ -1,3 +1,15 @@
+-- TEXT UNIQUE already creates a unique index, and Postgres unique constraints
+-- ignore NULLs, so a partial "WHERE share_slug IS NOT NULL" index would be a
+-- second B-tree maintained on every session write for the same guarantee.
 ALTER TABLE sessions ADD COLUMN IF NOT EXISTS share_slug TEXT UNIQUE;
 ALTER TABLE sessions ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT false;
-CREATE UNIQUE INDEX IF NOT EXISTS sessions_share_slug_idx ON sessions(share_slug) WHERE share_slug IS NOT NULL;
+
+-- The share page is read by signed-out visitors through the anon key, so RLS is
+-- the only gate here rather than defence in depth. Without this policy
+-- auth.uid() is NULL, "Users can CRUD own sessions" cannot match, and every
+-- share link 404s for exactly the audience the feature exists for.
+DROP POLICY IF EXISTS "Public can read published sessions" ON sessions;
+CREATE POLICY "Public can read published sessions" ON sessions
+  FOR SELECT TO anon, authenticated USING (is_public = true);
+
+CREATE INDEX IF NOT EXISTS sessions_is_public_idx ON sessions(is_public) WHERE is_public = true;

--- a/supabase/migrations/20260508120100_add_subscriptions.sql
+++ b/supabase/migrations/20260508120100_add_subscriptions.sql
@@ -13,14 +13,21 @@ CREATE TABLE IF NOT EXISTS subscriptions (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- RLS
+-- getUserSubscriptionTier() filters on user_id on the tier-gating hot path.
+CREATE INDEX IF NOT EXISTS subscriptions_user_id_idx ON subscriptions(user_id);
+
+-- RLS. The webhook and getUserSubscriptionTier use the service-role key, which
+-- bypasses RLS entirely, so users only ever need to read their own row. A
+-- permissive policy for writes would let any client grant itself Pro, since the
+-- anon key ships in the browser bundle.
 ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Users can read own subscription" ON subscriptions;
 CREATE POLICY "Users can read own subscription" ON subscriptions
   FOR SELECT USING (auth.uid() = user_id);
-CREATE POLICY "Service role can manage subscriptions" ON subscriptions
-  USING (true) WITH CHECK (true);
+
+REVOKE INSERT, UPDATE, DELETE ON subscriptions FROM anon, authenticated;
 
 -- updated_at trigger
-CREATE TRIGGER set_updated_at
+CREATE OR REPLACE TRIGGER set_updated_at
   BEFORE UPDATE ON subscriptions
   FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/20260512000100_add_share_link_password.sql
+++ b/supabase/migrations/20260512000100_add_share_link_password.sql
@@ -1,3 +1,31 @@
 -- Add optional password protection to shared sessions.
--- password_hash stores a bcrypt hash (cost 10); null means no password.
+-- share_password_hash stores a scrypt hash; null means no password.
 ALTER TABLE sessions ADD COLUMN IF NOT EXISTS share_password_hash TEXT;
+
+-- The share page only needs to know *whether* a password is set, never the hash
+-- itself. A generated column gives anon that boolean without exposing the
+-- secret, and it cannot drift from the hash the way a hand-maintained flag would.
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS has_share_password BOOLEAN
+  GENERATED ALWAYS AS (share_password_hash IS NOT NULL) STORED;
+
+-- "Public can read published sessions" (20260508120000) lets anon SELECT any row
+-- with is_public = true, so sessions now holds a secret in a table anonymous
+-- users can read. Without this, anyone could run
+--   GET /rest/v1/sessions?is_public=eq.true&select=share_password_hash
+-- and walk off with every share hash to crack offline -- defeating the gate.
+--
+-- A bare `REVOKE SELECT (share_password_hash) ... FROM anon` does NOT work: a
+-- table-level SELECT grant implies SELECT on every column, and the column-level
+-- revoke is silently ignored while it stands. The table grant must be dropped
+-- first and an explicit column list granted back.
+--
+-- Consequence: any column added to sessions later must be added to this GRANT or
+-- it will be invisible to the share page. `authenticated` keeps its table-level
+-- grant, so owner reads (getSession's select *) are unaffected.
+REVOKE SELECT ON sessions FROM anon;
+GRANT SELECT (
+  id, user_id, title, description, status, bpm, key_signature, time_signature,
+  genre, mood, parent_branch_id, created_at, updated_at, last_active_at,
+  share_slug, is_public, has_share_password
+) ON sessions TO anon;


### PR DESCRIPTION
## What

Production had **no `supabase_migrations.schema_migrations` table at all**. The schema was hand-built in the dashboard SQL editor and had drifted from the repo — five migrations had never been applied.

So `sessions.share_slug` and the whole `subscriptions` table did not exist. **Sharing 500'd and no user could ever become Pro.** That's why UNB-51 (share button) and UNB-56 (upgrade button) were correct in code and inert in production.

Verified against prod before/after, not inferred from files.

## Changes

**Applied the 5 missing migrations** + baselined migration history so `supabase db push` works from here.

**Security fixes found while applying them:**

- **`subscriptions` privilege escalation.** The `USING (true) WITH CHECK (true)` policy was named "Service role" but had no `TO`/`FOR` clause → defaulted to `FOR ALL TO PUBLIC` and OR'd past the `auth.uid()` policy. Any client with the anon key could grant itself Pro or read every customer's Stripe id. Dropped it (the service role bypasses RLS anyway) and revoked writes.
- **Sharing was dead twice over.** The column was missing *and* no anon SELECT policy existed — `auth.uid()` is NULL for a signed-out visitor, so nothing could match. Added the policy.
- **Password hash exposure.** The new anon policy makes `sessions` readable by signed-out visitors, which would have exposed every scrypt hash via `?select=share_password_hash`. Note: a column-level `REVOKE` is *silently ignored* while a table-level `SELECT` grant stands — so the table grant is dropped and an explicit column list granted instead. `has_share_password` is a generated column so the share page can tell if a password is set without reading the secret.

## Verified against prod

| Probe (anon key) | Before | After |
|---|---|---|
| Grant self Pro via `subscriptions` insert | would succeed once table existed | `42501 permission denied` |
| Read `share_password_hash` | readable | `42501 permission denied` |
| Read private sessions | blocked | blocked |
| `sessions.share_slug` exists | no | yes |

## Consequence worth knowing

`select("*")` is now **permission denied for anon**. `getSessionBySlug` selects an explicit column list, the share page reads `has_share_password`, and the verify route uses a service client (checking `is_public` first — it bypasses RLS, so that check is the only gate). **Any column added to `sessions` later must be added to the GRANT and to `SHARE_VIEWER_COLUMNS`.**

## Test

913/913 pass on Node 24, tsc + lint clean. (Suite is red on Node 25 — separate issue, UNB-73.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)